### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1711,7 +1711,7 @@
       "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "sequelize": {
-      "version": "4.44.0",
+      "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.44.0.tgz",
       "integrity": "sha512-2XhS+koWZT9odyPVmq1xKiWMOIAYGgpUSlUJ6EbWjJCjXbkTKKfde0w5axJQcDjbPYCBvX5UOgID7xmPHL2xTw==",
       "requires": {


### PR DESCRIPTION
Fixed vulnerability in older version of sequelize. Updated depndencies to 5.3.0.